### PR TITLE
change pk generation to use GENERATE_UUID()

### DIFF
--- a/gcp_billing_export.view.lkml
+++ b/gcp_billing_export.view.lkml
@@ -3,7 +3,7 @@ view: gcp_billing_export {
     sql:
       SELECT
         *,
-        ROW_NUMBER() OVER () pk
+        GENERATE_UUID() as pk
       FROM
         gcp_logs.gcp_billing_export_v1_#####_#####_######
       WHERE


### PR DESCRIPTION
GENERATE_UUID() is much more efficient gets around memory issues that ROW_NUMBER() runs into when calculating nested measures on the dataset.

Credit to Rob Grace at Looker for this find.