### PR TITLE
Jamiefry datatonic patch 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you have more than one project using BigQuery, repeat the steps above. All lo
 
 ### !IMPORTANT!
 The BigQuery Audit Logs export pulls in both the AuditData and BigQueryAuditMetadata logs. AuditData is the older version of the logs, and BigQueryAuditMetadata is the new which ADDS new columns. These are therefore unioned in the table. The lookml model pulls from the older version, but you have the ability to model the new columns into the model should you wish. 
-Please note, this means you should ONLY USE ROW COUNT with filters, be aware a simple count(*) will not yield number of queries without a filter applied.
+You should only use ROW COUNT with Method Name filter applied.
 
 #### Using the Google Cloud SDK
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ The BigQuery audit log export should now be set up. The table will be updated th
 
 If you have more than one project using BigQuery, repeat the steps above. All logs from different projects will be added to the same table, allowing easy querying across projects.
 
+### !IMPORTANT!
+The BigQuery Audit Logs export pulls in both the AuditData and BigQueryAuditMetadata logs. AuditData is the older version of the logs, and BigQueryAuditMetadata is the new which ADDS new columns. These are therefore unioned in the table. The lookml model pulls from the older version, but you have the ability to model the new columns into the model should you wish. 
+Please note, this means you should ONLY USE ROW COUNT with filters, be aware a simple count(*) will not yield number of queries without a filter applied.
+
 #### Using the Google Cloud SDK
 
 Alternatively, if you have the Google Cloud SDK installed, you can set up the BigQuery logging using the following command (make sure you in the project you want to set up the logging for by running ```gcloud config set project <project-name>```)

--- a/bigquery_data_access.view.lkml
+++ b/bigquery_data_access.view.lkml
@@ -90,6 +90,17 @@ view: bigquery_data_access {
     sql: ${TABLE}.trace ;;
   }
 
+# warning! a MethodName filter must be applied to this measure (number_of_queries) to gain number of queries without double counting.
+# if you want the number of run queries, use jobservice.jobcompleted.
+# 1	google.cloud.bigquery.v2.JobService.GetQueryResults
+# 2	google.cloud.bigquery.v2.JobService.InsertJob
+# 3	google.cloud.bigquery.v2.TableDataService.List
+# 4	jobservice.cancel
+# 5	jobservice.getqueryresults
+# 6	jobservice.insert
+# 7	jobservice.jobcompleted
+# 8	jobservice.query
+# 9	tabledataservice.list
   measure: number_of_queries {
     view_label: "BigQuery Data Access: Query Statistics"
     type: count


### PR DESCRIPTION
added in clarification: AuditData & BigQueryAuditMetadata are both present in this table, due to the filters we have applied in the new sink creation process.

BigQueryAuditMetadata the new version of logs, which reports resource interactions such as which tables were read from and written to by a given query job and which tables expired due to having an expiration time configured.

AuditData: The old version of logs, which reports API invocations, is present in the sink table, as is 