### PR TITLE
Clrenda datatonic - bug fix for cost calculation

### DIFF
--- a/bigquery_data_access.view.lkml
+++ b/bigquery_data_access.view.lkml
@@ -505,12 +505,12 @@ view: bigquery_data_access_job_statistics {
 
   dimension: billed_gigabytes {
     type: number
-    sql: 1.0*${billed_bytes}/1000000000 ;;
+    sql: 1.0*${billed_bytes}/1073741824 ;;
   }
 
   dimension: billed_terabytes {
     type: number
-    sql: 1.0*${billed_bytes}/1000000000000 ;;
+    sql: 1.0*${billed_bytes}/1099511627776 ;;
   }
 
   measure: total_billed_gigabytes {
@@ -579,7 +579,7 @@ view: bigquery_data_access_job_statistics {
 
   dimension: query_cost {
     type: number
-    sql: 5.0*${billed_bytes}/1000000000000 ;;
+    sql: 5.0*${billed_bytes}/1099511627776 ;;
     value_format_name: usd
   }
 


### PR DESCRIPTION
Updated the definitions for dimensions `billed_gigabytes`, `billed_terabytes` and `query_cost`.
This is because BigQuery calculates storage usage in Gibibytes (GiB), where 
1 GiB = 2^30 bytes = 1073741824 bytes and a Tebibyte (TiB) = 2^40 bytes = 1099511627776 bytes .
