### PR TITLE
Support JPY and fix liquid conditions

### DIFF
--- a/gcp_billing_export.view.lkml
+++ b/gcp_billing_export.view.lkml
@@ -62,9 +62,9 @@ view: gcp_billing_export {
     value_format_name: decimal_2
     html: {% if currency._value == 'GBP' %}
             <a href="{{ link }}"> £{{ rendered_value }}</a>
-          {% elsif currency == 'USD' %}
+          {% elsif currency._value == 'USD' %}
             <a href="{{ link }}"> ${{ rendered_value }}</a>
-          {% elsif currency == 'EUR' %}
+          {% elsif currency._value == 'EUR' %}
             <a href="{{ link }}"> €{{ rendered_value }}</a>
           {% else %}
             <a href="{{ link }}"> {{ rendered_value }} {{ currency._value }}</a>
@@ -84,9 +84,9 @@ view: gcp_billing_export {
     value_format_name: decimal_2
     html: {% if currency._value == 'GBP' %}
             <a href="{{ link }}"> £{{ rendered_value }}</a>
-          {% elsif currency == 'USD' %}
+          {% elsif currency._value == 'USD' %}
             <a href="{{ link }}"> ${{ rendered_value }}</a>
-          {% elsif currency == 'EUR' %}
+          {% elsif currency._value == 'EUR' %}
             <a href="{{ link }}"> €{{ rendered_value }}</a>
           {% else %}
             <a href="{{ link }}"> {{ rendered_value }} {{ currency._value }}</a>

--- a/gcp_billing_export.view.lkml
+++ b/gcp_billing_export.view.lkml
@@ -67,6 +67,8 @@ view: gcp_billing_export {
             <a href="{{ link }}"> ${{ rendered_value }}</a>
           {% when 'EUR' %}
             <a href="{{ link }}"> €{{ rendered_value }}</a>
+          {% when 'JPY' %}
+            <a href="{{ link }}"> ¥{{ rendered_value }}</a>
           {% else %}
             <a href="{{ link }}"> {{ rendered_value }} {{ currency._value }}</a>
           {% endcase %} ;;
@@ -90,6 +92,8 @@ view: gcp_billing_export {
             <a href="{{ link }}"> ${{ rendered_value }}</a>
           {% when 'EUR' %}
             <a href="{{ link }}"> €{{ rendered_value }}</a>
+          {% when 'JPY' %}
+            <a href="{{ link }}"> ¥{{ rendered_value }}</a>
           {% else %}
             <a href="{{ link }}"> {{ rendered_value }} {{ currency._value }}</a>
           {% endcase %} ;;

--- a/gcp_billing_export.view.lkml
+++ b/gcp_billing_export.view.lkml
@@ -60,15 +60,16 @@ view: gcp_billing_export {
     type: sum
     sql: ${TABLE}.cost ;;
     value_format_name: decimal_2
-    html: {% if currency._value == 'GBP' %}
+    html: {% case currency._value %}
+          {% when 'GBP' %}
             <a href="{{ link }}"> £{{ rendered_value }}</a>
-          {% elsif currency._value == 'USD' %}
+          {% when 'USD' %}
             <a href="{{ link }}"> ${{ rendered_value }}</a>
-          {% elsif currency._value == 'EUR' %}
+          {% when 'EUR' %}
             <a href="{{ link }}"> €{{ rendered_value }}</a>
           {% else %}
             <a href="{{ link }}"> {{ rendered_value }} {{ currency._value }}</a>
-          {% endif %} ;;
+          {% endcase %} ;;
     drill_fields: [gcp_billing_export_project.name, gcp_billing_export_service.description, sku_category, gcp_billing_export_sku.description, gcp_billing_export_usage.unit, gcp_billing_export_usage.total_usage, total_cost]
   }
 
@@ -82,15 +83,16 @@ view: gcp_billing_export {
     type: sum
     sql: ${gcp_billing_export_credits.credit_amount} ;;
     value_format_name: decimal_2
-    html: {% if currency._value == 'GBP' %}
+    html: {% case currency._value %}
+          {% when 'GBP' %}
             <a href="{{ link }}"> £{{ rendered_value }}</a>
-          {% elsif currency._value == 'USD' %}
+          {% when 'USD' %}
             <a href="{{ link }}"> ${{ rendered_value }}</a>
-          {% elsif currency._value == 'EUR' %}
+          {% when 'EUR' %}
             <a href="{{ link }}"> €{{ rendered_value }}</a>
           {% else %}
             <a href="{{ link }}"> {{ rendered_value }} {{ currency._value }}</a>
-          {% endif %} ;;
+          {% endcase %} ;;
     drill_fields: [gcp_billing_export_credits.credit_name,gcp_billing_export_credits.credit_amount]
   }
 


### PR DESCRIPTION
Support JPY for `total_cost` and `total_credit`. And I also fix the liquid conditions in 6517bf68b27be1309783801a45c9c4b2bf867c96 .